### PR TITLE
Disarm XSS path in xowiki-www-procs.tcl

### DIFF
--- a/tcl/xowiki-www-procs.tcl
+++ b/tcl/xowiki-www-procs.tcl
@@ -1892,7 +1892,8 @@ namespace eval ::xowiki {
       # }
 
       #:log "--after context delete_link=$delete_link "
-      set template [::$context_package_id get_parameter "template" ""]
+      # set template [::$context_package_id get_parameter "template" ""]
+      set template ""
       set page [self]
 
       foreach css [::$context_package_id get_parameter extra_css ""] {


### PR DESCRIPTION
Any request triggering the `view` method with a `template` query parameter /xowiki/?template=?template=<script>alert('xss') ;</script> seems vulnerable to me.